### PR TITLE
feat: 로그인(JWT 발급/인증) 기능 추가

### DIFF
--- a/backend/unimate/src/main/java/com/unimate/domain/user/user/controller/AuthController.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/user/user/controller/AuthController.java
@@ -1,0 +1,34 @@
+package com.unimate.domain.user.user.controller;
+
+import com.unimate.domain.user.user.dto.LoginRequest;
+import com.unimate.domain.user.user.dto.LoginResponse;
+import com.unimate.domain.user.user.service.AuthService;
+import com.unimate.global.jwt.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+
+    //인증 테스트용 api
+    @GetMapping("/me")
+    public ResponseEntity<?> getUserInfo(@AuthenticationPrincipal CustomUserPrincipal user) {
+        return ResponseEntity.ok(Map.of(
+                "userId", user.getUserId(),
+                "email", user.getEmail()
+        ));
+    }
+}

--- a/backend/unimate/src/main/java/com/unimate/domain/user/user/controller/UserController.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/user/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.unimate.domain.user.user.controller;
 import com.unimate.domain.user.user.dto.UserSignupRequest;
 import com.unimate.domain.user.user.dto.UserSignupResponse;
 import com.unimate.domain.user.user.service.UserService;
+import com.unimate.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,9 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class UserController {
     private final UserService userService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/signup")
     public ResponseEntity<UserSignupResponse> signup(@RequestBody UserSignupRequest request) {
         return ResponseEntity.ok(userService.signup(request));
     }
+
 }

--- a/backend/unimate/src/main/java/com/unimate/domain/user/user/dto/LoginRequest.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/user/user/dto/LoginRequest.java
@@ -1,0 +1,14 @@
+// com/unimate/domain/user/user/dto/LoginRequest.java
+package com.unimate.domain.user.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/backend/unimate/src/main/java/com/unimate/domain/user/user/dto/LoginResponse.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/user/user/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.unimate.domain.user.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private Long userId;
+    private String email;
+    private String accessToken;
+}

--- a/backend/unimate/src/main/java/com/unimate/domain/user/user/entity/User.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/user/user/entity/User.java
@@ -2,14 +2,16 @@ package com.unimate.domain.user.user.entity;
 
 import com.unimate.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class user extends BaseEntity {
+public class User extends BaseEntity {
     private String name;
     private String email;
     private String password;
@@ -17,7 +19,7 @@ public class user extends BaseEntity {
     private Boolean student_verified;
     private String university;
 
-    public user(String name, String email, String password, String gender, String university) {
+    public User(String name, String email, String password, String gender, String university) {
         this.name = name;
         this.email = email;
         this.password = password;

--- a/backend/unimate/src/main/java/com/unimate/domain/user/user/repository/UserRepository.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/user/user/repository/UserRepository.java
@@ -1,11 +1,11 @@
 package com.unimate.domain.user.user.repository;
 
-import com.unimate.domain.user.user.entity.user;
+import com.unimate.domain.user.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<user,Long> {
-    Optional<user> findByEmail(String email);
+public interface UserRepository extends JpaRepository<User,Long> {
+    Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
 }

--- a/backend/unimate/src/main/java/com/unimate/domain/user/user/service/AuthService.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/user/user/service/AuthService.java
@@ -1,0 +1,37 @@
+package com.unimate.domain.user.user.service;
+
+import com.unimate.domain.user.user.dto.LoginRequest;
+import com.unimate.domain.user.user.dto.LoginResponse;
+import com.unimate.domain.user.user.entity.User;
+import com.unimate.domain.user.user.repository.UserRepository;
+import com.unimate.global.jwt.JwtProvider;
+import com.unimate.global.jwt.JwtToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("이메일을 찾을 수 없습니다.")); //custom 예외 클래스 사용 예정
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        JwtToken token = jwtProvider.generateToken(user.getEmail(), user.getId());
+
+        return new LoginResponse(
+                user.getId(),
+                user.getEmail(),
+                token.getAccessToken()
+        );
+    }
+}

--- a/backend/unimate/src/main/java/com/unimate/domain/user/user/service/UserService.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/user/user/service/UserService.java
@@ -2,7 +2,7 @@ package com.unimate.domain.user.user.service;
 
 import com.unimate.domain.user.user.dto.UserSignupRequest;
 import com.unimate.domain.user.user.dto.UserSignupResponse;
-import com.unimate.domain.user.user.entity.user;
+import com.unimate.domain.user.user.entity.User;
 import com.unimate.domain.user.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -21,9 +21,11 @@ public class UserService {
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-        user newUser = new user(request.getName(), request.getEmail(), encodedPassword, request.getGender(), request.getUniversity());
+        User newUser = new User(request.getName(), request.getEmail(), encodedPassword, request.getGender(), request.getUniversity());
         userRepository.save(newUser);
 
         return new UserSignupResponse(newUser.getId(), newUser.getEmail(), newUser.getName());
     }
+
+
 }

--- a/backend/unimate/src/main/java/com/unimate/domain/userProfile/entity/userProfile.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/userProfile/entity/userProfile.java
@@ -1,6 +1,6 @@
 package com.unimate.domain.userProfile.entity;
 
-import com.unimate.domain.user.user.entity.user;
+import com.unimate.domain.user.user.entity.User;
 import com.unimate.domain.userProfile.dto.ProfileCreateRequest;
 import com.unimate.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -22,7 +22,7 @@ public class userProfile extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false,
             foreignKey = @ForeignKey(name = "fk_user_profile_user")) //제약조건 이름 정하기 없으면 해시값으로 생성되어 관리하기 힘들다고함
-    private user user;
+    private User user;
     private LocalDate birthDate;
     private Integer   sleepTime;
     private Boolean   isPetAllowed;
@@ -40,7 +40,7 @@ public class userProfile extends BaseEntity {
 
     @Builder
     private userProfile(
-            user user,
+            User user,
             LocalDate birthDate,
             Integer   sleepTime,
             Boolean   isPetAllowed,

--- a/backend/unimate/src/main/java/com/unimate/global/config/SecurityConfig.java
+++ b/backend/unimate/src/main/java/com/unimate/global/config/SecurityConfig.java
@@ -1,11 +1,47 @@
 package com.unimate.global.config;
 
+import com.unimate.global.jwt.JwtAuthEntryPoint;
+import com.unimate.global.jwt.JwtAuthFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtAuthFilter jwtFilter;
+    private final JwtAuthEntryPoint entryPoint;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(entryPoint))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/**",
+                                "/error",
+                                "/favicon.ico",
+                                "/h2-console/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/backend/unimate/src/main/java/com/unimate/global/jwt/CustomUserPrincipal.java
+++ b/backend/unimate/src/main/java/com/unimate/global/jwt/CustomUserPrincipal.java
@@ -1,0 +1,14 @@
+package com.unimate.global.jwt;
+
+public class CustomUserPrincipal {
+    private final Long userId;
+    private final String email;
+
+    public CustomUserPrincipal(Long userId, String email) {
+        this.userId = userId;
+        this.email = email;
+    }
+
+    public Long getUserId() { return userId; }
+    public String getEmail() { return email; }
+}

--- a/backend/unimate/src/main/java/com/unimate/global/jwt/JwtAuthEntryPoint.java
+++ b/backend/unimate/src/main/java/com/unimate/global/jwt/JwtAuthEntryPoint.java
@@ -1,0 +1,22 @@
+package com.unimate.global.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAuthEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(
+            HttpServletRequest request, HttpServletResponse response, AuthenticationException ex)
+            throws IOException {
+        log.error("Unauthorized: {}", ex.getMessage());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+}

--- a/backend/unimate/src/main/java/com/unimate/global/jwt/JwtAuthFilter.java
+++ b/backend/unimate/src/main/java/com/unimate/global/jwt/JwtAuthFilter.java
@@ -1,0 +1,61 @@
+package com.unimate.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        if (!jwtProvider.validateToken(token)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Token");
+            return;
+        }
+
+            String email = jwtProvider.getEmailFromToken(token);
+            Long userId = jwtProvider.getUserIdFromToken(token);
+
+            CustomUserPrincipal principal = new CustomUserPrincipal(userId, email);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
+
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) return bearer.substring(7);
+        return null;
+    }
+}

--- a/backend/unimate/src/main/java/com/unimate/global/jwt/JwtProvider.java
+++ b/backend/unimate/src/main/java/com/unimate/global/jwt/JwtProvider.java
@@ -1,0 +1,75 @@
+package com.unimate.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpirationTime;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpirationTime;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public JwtToken generateToken(String email, Long userId) {
+        Date now = new Date();
+
+        String accessToken = Jwts.builder()
+                .subject(email)
+                .claim("userId", userId)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + accessTokenExpirationTime))
+                .signWith(key)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + refreshTokenExpirationTime))
+                .signWith(key)
+                .compact();
+
+        return new JwtToken("Bearer", accessToken, refreshToken, accessTokenExpirationTime);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.warn("토큰 만료: {}", e.getMessage());
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("잘못된 토큰: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    public String getEmailFromToken(String token) {
+        Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+        return claims.getSubject();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+        return claims.get("userId", Long.class);
+    }
+}

--- a/backend/unimate/src/main/java/com/unimate/global/jwt/JwtToken.java
+++ b/backend/unimate/src/main/java/com/unimate/global/jwt/JwtToken.java
@@ -1,0 +1,15 @@
+package com.unimate.global.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class JwtToken {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long accessTokenExpiresIn;
+}


### PR DESCRIPTION
## 관련 이슈

- close #12 

## PR / 과제 설명 
- 로그인 로직 구현
- JWT 인증 필터 등록
   유효한 토큰을 검증 후 userId, email을 SecurityContext에 저장
   (각 API에서 @AuthenticationPrincipal CustomUserPrincipal user 로 받아 userId와 email 사용 가능)
- 보안 설정(SecurityConfig) 개선
- JWT 인증 예외 처리 및 로그 추가