### PR TITLE
[BE/fix] 매칭 선호도 등록 시, 시작 날짜가 종료 날짜보다 미래로 잡히는 것이 가능한 로직 오류 수정

### DIFF
--- a/backend/unimate/src/main/java/com/unimate/domain/userMatchPreference/controller/UserMatchPreferenceController.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/userMatchPreference/controller/UserMatchPreferenceController.java
@@ -24,7 +24,7 @@ public class UserMatchPreferenceController {
     @PutMapping("/me/preferences")
     public ResponseEntity<MatchPreferenceResponse> updateMyMatchPreference(
              @AuthenticationPrincipal CustomUserPrincipal user,
-             @RequestBody MatchPreferenceRequest requestDto
+             @Valid @RequestBody MatchPreferenceRequest requestDto
               ) {
 
          Long userId = user.getUserId();

--- a/backend/unimate/src/main/java/com/unimate/domain/userMatchPreference/dto/MatchPreferenceRequest.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/userMatchPreference/dto/MatchPreferenceRequest.java
@@ -1,12 +1,14 @@
 package com.unimate.domain.userMatchPreference.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.unimate.global.validator.ValidDateRange;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
 @Getter
+@ValidDateRange(startDate = "startUseDate", endDate = "endUseDate", message = "룸메이트 종료일은 시작일보다 빠를 수 없습니다.")
 public class MatchPreferenceRequest {
 
     @NotNull(message = "startUseDate 필드는 null일 수 없습니다.")

--- a/backend/unimate/src/main/java/com/unimate/global/validator/DateRangeValidator.java
+++ b/backend/unimate/src/main/java/com/unimate/global/validator/DateRangeValidator.java
@@ -1,0 +1,35 @@
+package com.unimate.global.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.beans.BeanWrapperImpl;
+
+import java.time.LocalDate;
+
+public class DateRangeValidator implements ConstraintValidator<ValidDateRange, Object> {
+
+    private String startDate;
+    private String endDate;
+
+    @Override
+    public void initialize(ValidDateRange constraintAnnotation) {
+        this.startDate = constraintAnnotation.startDate();
+        this.endDate = constraintAnnotation.endDate();
+    }
+
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        Object startDateValue = new BeanWrapperImpl(value).getPropertyValue(startDate);
+        Object endDateValue = new BeanWrapperImpl(value).getPropertyValue(endDate);
+
+        if (startDateValue == null || endDateValue == null) {
+            return true; // @NotNull annotation should handle this
+        }
+
+        if (startDateValue instanceof LocalDate && endDateValue instanceof LocalDate) {
+            return !((LocalDate) startDateValue).isAfter((LocalDate) endDateValue);
+        }
+
+        return false;
+    }
+}

--- a/backend/unimate/src/main/java/com/unimate/global/validator/ValidDateRange.java
+++ b/backend/unimate/src/main/java/com/unimate/global/validator/ValidDateRange.java
@@ -1,0 +1,21 @@
+package com.unimate.global.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = DateRangeValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidDateRange {
+    String message() default "룸메이트 종료일은 시작일보다 빠를 수 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    String startDate();
+    String endDate();
+}


### PR DESCRIPTION
## 관련 이슈

- close #75 

## PR / 과제 설명 
- 룸메이트 시작 기간이 종료 기간을 넘지 않도록 커스텀 벨리드 작성
