### PR TITLE
[FE/feat] 탈퇴한 사용자 알림 표시

### DIFF
--- a/backend/unimate/src/main/java/com/unimate/domain/chatroom/dto/ChatRoomDetailResponse.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/chatroom/dto/ChatRoomDetailResponse.java
@@ -8,7 +8,8 @@ public class ChatRoomDetailResponse {
     private Long user1Id;
     private Long user2Id;
     private String partnerName;        // 상대방 이름
-    private String partnerUniversity;  // 상대방 대학교
+    private String partnerUniversity;// 상대방 대학교
+    private Boolean isPartnerDeleted;  // 상대방이 탈퇴한 사용자인지 여부
     private String status; // ACTIVE | CLOSED
     private String createdAt;
     private String updatedAt;

--- a/backend/unimate/src/main/java/com/unimate/domain/chatroom/service/ChatroomService.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/chatroom/service/ChatroomService.java
@@ -82,12 +82,23 @@ public class ChatroomService {
         
         // 상대방 ID 및 정보 조회
         Long partnerId = partnerIdOf(me, room);
-        String partnerName = userRepository.findById(partnerId)
-                .map(com.unimate.domain.user.user.entity.User::getName)
-                .orElse("알 수 없는 사용자");
-        String partnerUniversity = userRepository.findById(partnerId)
-                .map(com.unimate.domain.user.user.entity.User::getUniversity)
-                .orElse("");
+        // 상대방이 존재하는지 확인
+        boolean isPartnerDeleted = !userRepository.existsById(partnerId);
+
+        String partnerName;
+        String partnerUniversity;
+
+        if (isPartnerDeleted) {
+            partnerName = "탈퇴한 사용자";
+            partnerUniversity = "";
+        } else {
+            partnerName = userRepository.findById(partnerId)
+                    .map(com.unimate.domain.user.user.entity.User::getName)
+                    .orElse("알 수 없는 사용자");
+            partnerUniversity = userRepository.findById(partnerId)
+                    .map(com.unimate.domain.user.user.entity.User::getUniversity)
+                    .orElse("");
+        }
         
         return new ChatRoomDetailResponse(
                 room.getId(),
@@ -95,6 +106,7 @@ public class ChatroomService {
                 room.getUser2Id(),
                 partnerName,
                 partnerUniversity,
+                isPartnerDeleted,
                 room.getStatus().name(),
                 ISO.format(room.getCreatedAt()),
                 ISO.format(room.getUpdatedAt()),

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -183,12 +183,7 @@ export default function ChatListPage() {
                             </span>
                           )}
                         </div>
-                        <div className="flex items-center gap-3">
-                          {chat.unreadCount && chat.unreadCount > 0 && (
-                            <span className="bg-[#EF4444] text-white text-xs px-2 py-1 rounded-full min-w-[20px] text-center font-semibold">
-                              {chat.unreadCount > 99 ? '99+' : chat.unreadCount}
-                            </span>
-                          )}
+                        <div className="flex flex-col items-end gap-1">
                           <span className="text-sm text-[#9CA3AF]">
                             {chat.lastMessageTime 
                               ? new Date(chat.lastMessageTime).toLocaleTimeString('ko-KR', { 
@@ -198,6 +193,11 @@ export default function ChatListPage() {
                               : new Date(chat.createdAt).toLocaleDateString('ko-KR')
                             }
                           </span>
+                          {chat.unreadCount && chat.unreadCount > 0 ? (
+                            <span className="bg-[#EF4444] text-white text-xs px-2 py-1 rounded-full min-w-[20px] text-center font-semibold">
+                              {chat.unreadCount > 99 ? '99+' : chat.unreadCount}
+                            </span>
+                          ) : null}
                         </div>
                       </div>
                       <p className="text-[#6B7280] truncate">

--- a/frontend/src/components/chat/ChatRoomView.tsx
+++ b/frontend/src/components/chat/ChatRoomView.tsx
@@ -17,6 +17,7 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
   const [text, setText] = useState('')
   const [partnerName, setPartnerName] = useState('채팅 상대')
   const [partnerInfo, setPartnerInfo] = useState('')
+  const [isPartnerDeleted, setIsPartnerDeleted] = useState(false)
 
   // 채팅방 정보 조회 및 읽음 처리
   useEffect(() => {
@@ -25,9 +26,10 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
         const response = await apiClient.get(`/api/v1/chatrooms/${chatroomId}`)
         const chatroomData = response.data
         
-        // 백엔드에서 이미 partnerName, partnerUniversity를 보내줌
+        // 백엔드에서 이미 partnerName, partnerUniversity, isPartnerDeleted를 보내줌
         setPartnerName(chatroomData.partnerName || '채팅 상대')
         setPartnerInfo(chatroomData.partnerUniversity || '')
+        setIsPartnerDeleted(chatroomData.isPartnerDeleted || false)
 
         // 채팅방에 들어갔을 때 읽음 처리
         try {
@@ -80,8 +82,14 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
               <ArrowLeft className="w-5 h-5 text-gray-600" />
             </button>
             <div>
-              <h2 className="font-semibold text-[#111827]">{partnerName}</h2>
-              {partnerInfo && <p className="text-sm text-[#6B7280]">{partnerInfo}</p>}
+              <h2 className={`font-semibold ${isPartnerDeleted ? 'text-red-500' : 'text-[#111827]'}`}>
+                {partnerName}
+              </h2>
+              {isPartnerDeleted ? (
+                <p className="text-sm text-red-400">이 사용자는 탈퇴했습니다</p>
+              ) : (
+                partnerInfo && <p className="text-sm text-[#6B7280]">{partnerInfo}</p>
+              )}
             </div>
           </div>
         </div>
@@ -134,26 +142,32 @@ export default function ChatRoomView({ chatroomId }: ChatRoomViewProps) {
       {/* Message Input */}
       <div className="bg-white border-t border-[#E5E7EB] sticky bottom-0">
         <div className="px-4 py-4">
-          <div className="flex gap-3">
-            <input
-              placeholder="메시지를 입력하세요..."
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              onKeyPress={(e) => {
-                if (e.key === 'Enter') {
-                  sendMessage(text)
-                }
-              }}
-              className="flex-1 px-4 py-3 border border-[#E5E7EB] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#4F46E5] focus:border-transparent"
-            />
-            <button
-              onClick={() => sendMessage(text)}
-              disabled={!text.trim()}
-              className="w-12 h-12 bg-[#4F46E5] text-white rounded-xl flex items-center justify-center hover:bg-[#4338CA] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              <Send className="w-5 h-5" />
-            </button>
-          </div>
+          {isPartnerDeleted ? (
+            <div className="text-center py-4 text-gray-500 bg-gray-50 rounded-xl">
+              <p className="text-sm">탈퇴한 사용자와는 메시지를 주고받을 수 없습니다</p>
+            </div>
+          ) : (
+            <div className="flex gap-3">
+              <input
+                placeholder="메시지를 입력하세요..."
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                onKeyPress={(e) => {
+                  if (e.key === 'Enter') {
+                    sendMessage(text)
+                  }
+                }}
+                className="flex-1 px-4 py-3 border border-[#E5E7EB] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#4F46E5] focus:border-transparent"
+              />
+              <button
+                onClick={() => sendMessage(text)}
+                disabled={!text.trim()}
+                className="w-12 h-12 bg-[#4F46E5] text-white rounded-xl flex items-center justify-center hover:bg-[#4338CA] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                <Send className="w-5 h-5" />
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- close #116 

## PR / 과제 설명 
## 🎯 구현 내용
- 채팅방에서 상대방이 탈퇴한 사용자일 때 명확한 알림 표시
- 탈퇴한 사용자와의 메시지 전송 비활성화
- 채팅 목록 UI 개선

## 📝 상세 변경사항

### 백엔드
- `ChatRoomDetailResponse`에 `isPartnerDeleted` 필드 추가
- `ChatroomService.getDetail()`에서 상대방이 탈퇴했는지 확인하는 로직 추가

### 프론트엔드
- **채팅방 상세 페이지**:
  - 상대방이 탈퇴한 사용자면 이름을 빨간색으로 표시
  - "이 사용자는 탈퇴했습니다" 메시지 표시
  - 메시지 입력창 비활성화 및 안내 메시지 표시

- **채팅 목록 페이지**:
  - 안 읽은 메시지 표시 위치를 시간 옆에서 시간 밑으로 이동
  - 안 읽은 메시지가 0개일 때 표시 숨김

- **인증 관리**:
  - `AuthContext`에 `isLoading` 상태 추가
  - F5 새로고침 시 로그인 상태 유지 개선

