### PR TITLE
[BE/fix] 최종 결과를 양방향 응답에 맞게 수정 

### DIFF
--- a/backend/unimate/src/main/java/com/unimate/domain/match/service/MatchService.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/match/service/MatchService.java
@@ -310,7 +310,7 @@ public class MatchService {
         List<MatchResultResponse.MatchResultItem> results = matchRepository.findBySenderIdOrReceiverId(userId)
                 .stream()
                 .filter(match -> match.getMatchStatus() == MatchStatus.ACCEPTED)
-                .map(matchUtilityService::toMatchResultItem)
+                .map(match -> matchUtilityService.toMatchResultItem(match, userId))
                 .toList();
 
         return new MatchResultResponse(results);

--- a/backend/unimate/src/main/java/com/unimate/domain/match/service/MatchUtilityService.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/match/service/MatchUtilityService.java
@@ -94,13 +94,18 @@ public class MatchUtilityService {
     /**
      * Match를 MatchResultItem으로 변환
      */
-    public MatchResultResponse.MatchResultItem toMatchResultItem(Match match) {
+    public MatchResultResponse.MatchResultItem toMatchResultItem(Match match, Long currentUserId) {
+        // 현재 사용자 기준으로 상대방 정보 설정
+        User partner = match.getSender().getId().equals(currentUserId) 
+            ? match.getReceiver() 
+            : match.getSender();
+            
         return new MatchResultResponse.MatchResultItem(
                 match.getId(),
-                match.getSender().getId(),
-                match.getSender().getName(),
-                match.getReceiver().getId(),
-                match.getReceiver().getName(),
+                currentUserId,
+                match.getSender().getId().equals(currentUserId) ? match.getSender().getName() : partner.getName(),
+                partner.getId(),
+                partner.getName(),
                 match.getMatchType(),
                 match.getMatchStatus(),
                 match.getPreferenceScore(),


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #161 

## PR / 과제 설명 

확정된 룸메이트 목록에서 사용자 자신이 표시되는 문제가 발생
사용자는 상대방을 확인해야 하지만, 현재 로직에서는 본인 정보가 표시되는 버그가 존재

`MatchUtilityService`와 `MatchService` 
- 로직을 리팩터링하여 현재 로그인한 사용자를 기준으로 상대방 정보를 동적으로 표시하도록 수정
