### PR TITLE
[BE/fix] 유사도 로직 업데이트 및 룸메이트 추천 목록 조회 필터링 추가

### DIFF
--- a/backend/unimate/src/main/java/com/unimate/domain/match/service/SimilarityCalculator.java
+++ b/backend/unimate/src/main/java/com/unimate/domain/match/service/SimilarityCalculator.java
@@ -1,5 +1,6 @@
 package com.unimate.domain.match.service;
 
+import com.unimate.domain.userMatchPreference.entity.UserMatchPreference;
 import com.unimate.domain.userProfile.entity.UserProfile;
 import org.springframework.stereotype.Service;
 
@@ -23,37 +24,37 @@ public class SimilarityCalculator {
     private static final double WEIGHT_PET = 0.10;
     private static final double WEIGHT_LIFESTYLE = 0.10;
 
-    public double calculateSimilarity(UserProfile userA, UserProfile userB) {
+    public double calculateSimilarity(UserMatchPreference preference, UserProfile profile) {
         // Null 체크 : 프로필 또는 필수 정보가 없으면 0점 반환
-        if (userA == null || userB == null || userA.getUser() == null || userB.getUser() == null) return 0.0;
+        if (preference == null || profile == null || profile.getUser() == null) return 0.0;
 
         // 항목별 점수 계산 & 카테고리별로 묶음
 
         // 흡연 점수
-        double smokerScore = calculateBooleanScore(userA.getIsSmoker(), userB.getIsSmoker());
+        double smokerScore = calculateBooleanScore(preference.getIsSmoker(), profile.getIsSmoker());
 
         // 수면 점수
-        double sleepScore = calculateIntegerScore(userA.getSleepTime(), userB.getSleepTime());
+        double sleepScore = calculateIntegerScore(preference.getSleepTime(), profile.getSleepTime());
 
         // 반려동물 점수
-        double petScore = calculateBooleanScore(userA.getIsPetAllowed(), userB.getIsPetAllowed());
+        double petScore = calculateBooleanScore(preference.getIsPetAllowed(), profile.getIsPetAllowed());
 
         // 나이 차이 점수
-        double ageGapScore = calculateAgeGapScore(userA, userB);
+        double ageGapScore = calculateAgeGapScore(preference.getPreferredAgeGap(), profile.getUser().getBirthDate());
 
         // 청결 점수 (청소 빈도 + 위생 수준)
-        double cleaningFrequencyScore = calculateIntegerScore(userA.getCleaningFrequency(), userB.getCleaningFrequency());
-        double hygieneLevelScore = calculateIntegerScore(userA.getHygieneLevel(), userB.getHygieneLevel());
+        double cleaningFrequencyScore = calculateIntegerScore(preference.getCleaningFrequency(), profile.getCleaningFrequency());
+        double hygieneLevelScore = calculateIntegerScore(preference.getHygieneLevel(), profile.getHygieneLevel());
         double cleanlinessScore = (cleaningFrequencyScore + hygieneLevelScore) / 2.0;
 
         // 소음 점수 (소음 민감도 + 코골이 여부)
-        double noiseSensitivityScore = calculateIntegerScore(userA.getNoiseSensitivity(), userB.getNoiseSensitivity());
-        double snoringScore = calculateBooleanScore(userA.getIsSnoring(), userB.getIsSnoring());
+        double noiseSensitivityScore = calculateIntegerScore(preference.getNoiseSensitivity(), profile.getNoiseSensitivity());
+        double snoringScore = calculateBooleanScore(preference.getIsSnoring(), profile.getIsSnoring());
         double noiseScore = (noiseSensitivityScore + snoringScore) / 2.0;
 
         // 생활방식 점수 (음주 빈도 + 방문자 빈도)
-        double drinkingFrequencyScore = calculateIntegerScore(userA.getDrinkingFrequency(), userB.getDrinkingFrequency());
-        double guestFrequencyScore = calculateIntegerScore(userA.getGuestFrequency(), userB.getGuestFrequency());
+        double drinkingFrequencyScore = calculateIntegerScore(preference.getDrinkingFrequency(), profile.getDrinkingFrequency());
+        double guestFrequencyScore = calculateIntegerScore(preference.getGuestFrequency(), profile.getGuestFrequency());
         double lifestyleScore = (drinkingFrequencyScore + guestFrequencyScore) / 2.0;
 
 
@@ -71,43 +72,45 @@ public class SimilarityCalculator {
 
     }
 
-    private double calculateIntegerScore(Integer valueA, Integer valueB) {
-        if (valueA == null || valueB == null) {
+    private double calculateIntegerScore(Integer preferenceValue, Integer profileValue) {
+        if (preferenceValue == null || profileValue == null) {
             return 0.0;
         }
-        return 1.0 - (Math.abs(valueA - valueB) / SCALE_RANGE);
+        // 선호도와 프로필 값이 얼마나 다른지를 계산. 점수가 높을수록 유사함.
+        return 1.0 - (Math.abs(preferenceValue - profileValue) / SCALE_RANGE);
     }
 
-    private double calculateBooleanScore(Boolean valueA, Boolean valueB) {
-        if (valueA == null || valueB == null) {
+    private double calculateBooleanScore(Boolean preferenceValue, Boolean profileValue) {
+        if (preferenceValue == null || profileValue == null) {
             return 0.0;
         }
-        return Objects.equals(valueA, valueB) ? 1.0 : 0.0;
+        // 선호도와 프로필 값이 일치하면 1점, 아니면 0점
+        return Objects.equals(preferenceValue, profileValue) ? 1.0 : 0.0;
     }
 
-    private double calculateAgeGapScore(UserProfile profileA, UserProfile profileB) {
-        LocalDate birthDateA = profileA.getUser().getBirthDate();
-        LocalDate birthDateB = profileB.getUser().getBirthDate();
-        Integer preferredGapA = profileA.getPreferredAgeGap();
-        Integer preferredGapB = profileB.getPreferredAgeGap();
-
-        if (birthDateA == null || birthDateB == null || preferredGapA == null || preferredGapB == null) {
+    private double calculateAgeGapScore(Integer preferredAgeBlock, LocalDate targetBirthDate) {
+        if (targetBirthDate == null || preferredAgeBlock == null) {
             return 0.0;
         }
 
-        int ageA = Period.between(birthDateA, LocalDate.now()).getYears();
-        int ageB = Period.between(birthDateB, LocalDate.now()).getYears();
+        int targetAge = Period.between(targetBirthDate, LocalDate.now()).getYears();
+        int targetAgeBlock = getAgeBlock(targetAge);
 
-        boolean isASatisfied = isAgeInRange(ageB, preferredGapA);
-        boolean isBSatisfied = isAgeInRange(ageA, preferredGapB);
-
-        if (isASatisfied && isBSatisfied) {
-            return 1.0; // 둘 다 만족
-        } else if (isASatisfied || isBSatisfied) {
-            return 0.5; // 한 명만 만족
-        } else {
-            return 0.0; // 둘 다 불만족
+        if (targetAgeBlock == 0) { // 나이가 유효 범위 밖이면 0점
+            return 0.0;
         }
+
+        // 나의 선호 블럭 번호와 상대의 실제 나이 블럭 번호를 비교하여 점수 계산
+        return calculateIntegerScore(preferredAgeBlock, targetAgeBlock);
+    }
+
+    private int getAgeBlock(int age) {
+        if (age >= 20 && age <= 22) return 1;
+        if (age >= 23 && age <= 25) return 2;
+        if (age >= 26 && age <= 28) return 3;
+        if (age >= 29 && age <= 30) return 4;
+        if (age >= 31) return 5;
+        return 0; // 범위 밖의 나이는 0점 처리
     }
 
     private boolean isAgeInRange(int age, int rangeCategory) {

--- a/frontend/src/app/matches/page.tsx
+++ b/frontend/src/app/matches/page.tsx
@@ -39,6 +39,8 @@ const PreferencePrompt = ({ onOpenModal }: { onOpenModal: () => void }) => (
   </div>
 );
 
+import AppHeader from '@/components/layout/AppHeader';
+
 export default function MatchesPage() {
   const [users, setUsers] = useState<RecommendedUser[]>([]);
   const [filteredUsers, setFilteredUsers] = useState<RecommendedUser[]>([]);
@@ -233,6 +235,7 @@ export default function MatchesPage() {
 
   return (
     <>
+      <AppHeader />
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 sm:p-6 lg:p-8">
         <div className="max-w-6xl mx-auto">
           {isLoading ? (


### PR DESCRIPTION
## 관련 이슈

- close #171 

## PR / 과제 설명 

- 유사도 로직
    - SimilarityCalculator의 계산 로직 업데이트. profile-profile 간의 비교에서 profile-preference 간 비교로 수정
    - 변경점 : SimilarityCalculator의 내부 계산식과, 호출하는 부분에서 받는 profile 객체 하나를 preference 로만 수정

- 목록 조회
    - type과 status가 REQUEST | PENDING (상호 좋아요로 채팅방이 열린 row) 는 조회 안되게 수정